### PR TITLE
remove need for hardcoded member_id

### DIFF
--- a/helpers/pipeline.py
+++ b/helpers/pipeline.py
@@ -106,7 +106,7 @@ def otf_source(args) -> Generator[DltResource, None, None]:
                     "data_selector": "$",
                     "params": {
                         "classHistoryUuid": "{resources.bookings.workout.id}",
-                        "maxDataPoints": 853
+                        "maxDataPoints": 150
                     },
                 },
             },

--- a/helpers/pipeline.py
+++ b/helpers/pipeline.py
@@ -10,7 +10,7 @@ from .auth import OAuth2OTF
 
 
 @dlt.source
-def otf_source(args, member_uuid:str = dlt.secrets["member_uuid"]) -> Generator[DltResource, None, None]:
+def otf_source(args) -> Generator[DltResource, None, None]:
 
 
     def invalidate_null_content(response: Response) -> Response:
@@ -42,6 +42,7 @@ def otf_source(args, member_uuid:str = dlt.secrets["member_uuid"]) -> Generator[
                 "name": "me",
                 "endpoint": {
                     "path": "https://api.orangetheory.io/v1/people/me",
+                    "data_selector": "$",
                     "paginator": "single_page",
                 },
             },
@@ -59,7 +60,7 @@ def otf_source(args, member_uuid:str = dlt.secrets["member_uuid"]) -> Generator[
                         "starts_after": {
                             "type": "incremental",
                             "cursor_path": "created_at",
-                            "initial_value": "2021-01-01T00:00:00Z",
+                            "initial_value": "2025-01-01T00:00:00Z",
                         },
                         "ends_before": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
                         "include_canceled": "false",
@@ -82,7 +83,7 @@ def otf_source(args, member_uuid:str = dlt.secrets["member_uuid"]) -> Generator[
                 "name": "body_composition",
                 "primary_key": "scanResultUUId",
                 "endpoint": {
-                    "path": f"https://api.orangetheory.co/member/members/{member_uuid}/body-composition",
+                    "path": "https://api.orangetheory.co/member/members/{resources.me.mbo_client_id}/body-composition",
                     "paginator": "single_page",
                 }
             },
@@ -90,7 +91,7 @@ def otf_source(args, member_uuid:str = dlt.secrets["member_uuid"]) -> Generator[
                 "name": "heart_rate",
                 "primary_key": "memberUuid",
                 "endpoint": {
-                    "path": f"https://api.yuzu.orangetheory.com/v1/physVars/maxHr/history?memberUuid={member_uuid}",
+                    "path": "https://api.yuzu.orangetheory.com/v1/physVars/maxHr/history?memberUuid={resources.me.mbo_client_id}",
                     "paginator": "single_page",
                     "data_selector": "$",
                 },
@@ -105,15 +106,16 @@ def otf_source(args, member_uuid:str = dlt.secrets["member_uuid"]) -> Generator[
                     "data_selector": "$",
                     "params": {
                         "classHistoryUuid": "{resources.bookings.workout.id}",
-                        "maxDataPoints": 150
+                        "maxDataPoints": 853
                     },
                 },
             },
             {
                 "name": "challenges",
                 "primary_key": ["ChallengeCategoryId", "ChallengeSubCategoryId"],
+                "include_from_parent": ["mbo_client_id"],
                 "endpoint": {
-                    "path": f"https://api.orangetheory.co/challenges/v3.1/member/{member_uuid}",
+                    "path": "https://api.orangetheory.co/challenges/v3.1/member/{resources.me.mbo_client_id}",
                     "data_selector": "$.Dto[Programs,Challenges][*]",
                 },
             },
@@ -123,7 +125,7 @@ def otf_source(args, member_uuid:str = dlt.secrets["member_uuid"]) -> Generator[
                 "include_from_parent": ["ChallengeSubCategoryId"],
                 "max_table_nesting": 1,
                 "endpoint": {
-                    "path": f"https://api.orangetheory.co/challenges/v3/member/{member_uuid}/benchmarks",
+                    "path": "https://api.orangetheory.co/challenges/v3/member/{resources.challenges._me_mbo_client_id}/benchmarks",
                     "paginator": "single_page",
                     "data_selector": "$.Dto",
                     "params": {
@@ -135,9 +137,10 @@ def otf_source(args, member_uuid:str = dlt.secrets["member_uuid"]) -> Generator[
             {
                 # benchmarks have a different schema than challenges, but same endpoint
                 "name": "benchmarks",
+                "include_from_parent": ["mbo_client_id"],
                 "primary_key": ["EquipmentId", "EquipmentName"],
                 "endpoint": {
-                    "path": f"https://api.orangetheory.co/challenges/v3.1/member/{member_uuid}",
+                    "path": "https://api.orangetheory.co/challenges/v3.1/member/{resources.me.mbo_client_id}",
                     "data_selector": "$.Dto.Benchmarks[*]",
                 },
             },
@@ -145,7 +148,7 @@ def otf_source(args, member_uuid:str = dlt.secrets["member_uuid"]) -> Generator[
                 "name": "benchmark_activity",
                 "primary_key": ["ChallengeCategoryId", "EquipmentId"],
                 "endpoint": {
-                    "path": f"https://api.orangetheory.co/challenges/v3/member/{member_uuid}/benchmarks",
+                    "path": "https://api.orangetheory.co/challenges/v3/member/{resources.benchmarks._me_mbo_client_id}/benchmarks",
                     "paginator": "single_page",
                     "data_selector": "$.Dto",
                     "params": {

--- a/helpers/pipeline.py
+++ b/helpers/pipeline.py
@@ -60,7 +60,7 @@ def otf_source(args) -> Generator[DltResource, None, None]:
                         "starts_after": {
                             "type": "incremental",
                             "cursor_path": "created_at",
-                            "initial_value": "2025-01-01T00:00:00Z",
+                            "initial_value": "2021-01-01T00:00:00Z",
                         },
                         "ends_before": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
                         "include_canceled": "false",


### PR DESCRIPTION
This pull request updates the Orangetheory Fitness data pipeline to improve how member identifiers are handled, enhance endpoint flexibility, and adjust some data extraction parameters. The most significant changes involve removing the hardcoded `member_uuid` in favor of dynamic resource-based identifiers, updating API endpoint paths, and modifying certain query parameters to better reflect current data needs.

**Dynamic Member Identifier Handling:**

* Removed the `member_uuid` argument from the `otf_source` function and replaced all hardcoded uses of `member_uuid` in API endpoint paths with dynamic references to resource-based identifiers like `{resources.me.mbo_client_id}`. This makes the pipeline more flexible and less dependent on secrets. [[1]](diffhunk://#diff-22c0021d18ed3a068c86bce14affec30610eb482c9c90ac462ff34849d60a4b3L13-R13) [[2]](diffhunk://#diff-22c0021d18ed3a068c86bce14affec30610eb482c9c90ac462ff34849d60a4b3L85-R94) [[3]](diffhunk://#diff-22c0021d18ed3a068c86bce14affec30610eb482c9c90ac462ff34849d60a4b3L108-R118) [[4]](diffhunk://#diff-22c0021d18ed3a068c86bce14affec30610eb482c9c90ac462ff34849d60a4b3L126-R128) [[5]](diffhunk://#diff-22c0021d18ed3a068c86bce14affec30610eb482c9c90ac462ff34849d60a4b3R140-R151)

**API Endpoint and Parameter Updates:**

* Added `data_selector` to the `me` endpoint for more precise data extraction.

**Data Structure and Inheritance Improvements:**

* Added `include_from_parent` fields to several resources (e.g., `challenges`, `benchmarks`) to ensure necessary parent identifiers are available in child resources, supporting better data relationships and lookups. [[1]](diffhunk://#diff-22c0021d18ed3a068c86bce14affec30610eb482c9c90ac462ff34849d60a4b3L108-R118) [[2]](diffhunk://#diff-22c0021d18ed3a068c86bce14affec30610eb482c9c90ac462ff34849d60a4b3R140-R151)

These changes collectively make the pipeline more robust, maintainable, and adaptable to changes in API structure or authentication.